### PR TITLE
Correct parameter type for ListUnitFiles

### DIFF
--- a/internal/pkg/systemd/units.go
+++ b/internal/pkg/systemd/units.go
@@ -476,7 +476,7 @@ type ListUnitFilesParams struct {
 }
 
 // returns the unit files known to systemd
-func (conn *Connection) ListUnitFiles(ctx context.Context, req *mcp.CallToolRequest, params *EnableParams) (res *mcp.CallToolResult, _ any, err error) {
+func (conn *Connection) ListUnitFiles(ctx context.Context, req *mcp.CallToolRequest, params *ListUnitFilesParams) (res *mcp.CallToolResult, _ any, err error) {
 	unitList, err := conn.dbus.ListUnitFilesContext(ctx)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
The ListUnitFiles function was incorrectly using *EnableParams as its parameter type, leading to a runtime JSON unmarshalling error due to a type mismatch.

This commit changes the function signature to use the correct *ListUnitFilesParams type, resolving the runtime error and aligning the function with its intended parameters.